### PR TITLE
feat: initial impl of HyParView and Plumtree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ once_cell = "1.18.0"
 rand = "0.8.5"
 rand_core = "0.6.4"
 serde = { version = "1.0.164", features = ["derive"] }
+tracing = "0.1.37"
 url = "2.4.0"
 
 [dev-dependencies]
 hex = "0.4.3"
+tracing-subscriber = "0.3.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,12 @@ repository = "https://github.com/n0-computer/iroh-sync"
 
 [dependencies]
 blake3 = "1.3.3"
+bytes = { version = "1.4.0", features = ["serde"] }
 crossbeam = "0.8.2"
+data-encoding = "2.4.0"
+derive_more = "0.99.17"
 ed25519-dalek = { version = "2.0.0-rc.2", features = ["serde", "rand_core"] }
+indexmap = "1.9.3"
 once_cell = "1.18.0"
 rand = "0.8.5"
 rand_core = "0.6.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ derive_more = "0.99.17"
 ed25519-dalek = { version = "2.0.0-rc.2", features = ["serde", "rand_core"] }
 indexmap = "1.9.3"
 once_cell = "1.18.0"
-rand = "0.8.5"
+rand = { version = "0.8.5", features = ["std_rng"] }
 rand_core = "0.6.4"
 serde = { version = "1.0.164", features = ["derive"] }
 tracing = "0.1.37"

--- a/src/gossipswarm/hyparview.rs
+++ b/src/gossipswarm/hyparview.rs
@@ -556,12 +556,7 @@ where
         }
     }
 
-    fn add_active_unchecked(
-        &mut self,
-        peer: PA,
-        priority: Priority,
-        io: &mut impl IO<PA>,
-    ) {
+    fn add_active_unchecked(&mut self, peer: PA, priority: Priority, io: &mut impl IO<PA>) {
         self.passive_view.remove(&peer);
         self.active_view.insert(peer);
         debug!(peer = ?self.me, other = ?peer, "add to active view");

--- a/src/gossipswarm/hyparview.rs
+++ b/src/gossipswarm/hyparview.rs
@@ -56,10 +56,11 @@ pub enum Message<PA> {
     /// Request to add sender to an active view of recipient. If `highPriority` is set, it cannot
     /// be denied.
     Neighbor(Neighbor),
-    /// Disconnect request. If `alive` is set, sender can safely be added to passive set for future
-    /// reconnections.
-    /// If `response` is set, recipient should answer with its own `Disconnect` (with
-    /// respond=false) as well.
+    /// Request to disconnect from a peer.
+    /// If `alive` is true, the other peer is not shutting down, so it should be added to the
+    /// passive set.
+    /// If `respond` is true, the peer should answer the disconnect request before shutting down
+    /// the connection.
     Disconnect(Disconnect),
 }
 

--- a/src/gossipswarm/hyparview.rs
+++ b/src/gossipswarm/hyparview.rs
@@ -176,29 +176,24 @@ pub struct State<PA, RG = ThreadRng> {
     pending_neighbor_requests: HashSet<PA>,
 }
 
-impl<PA> State<PA, rand::rngs::OsRng>
+impl<PA, RG> State<PA, RG>
 where
     PA: PeerAddress,
+    RG: Rng,
 {
-    pub fn new(me: PA, config: Config) -> Self {
+    pub fn new(me: PA, config: Config, rng: RG) -> Self {
         Self {
             me,
             active_view: IndexSet::new(),
             passive_view: IndexSet::new(),
             config,
             shuffle_scheduled: false,
-            rng: rand::rngs::OsRng,
+            rng,
             stats: Stats::default(),
             pending_neighbor_requests: Default::default(),
         }
     }
-}
 
-impl<PA, RG> State<PA, RG>
-where
-    PA: PeerAddress,
-    RG: Rng,
-{
     pub fn handle(&mut self, event: InEvent<PA>, now: Instant, io: &mut impl IO<PA>) {
         match event {
             InEvent::RecvMessage(from, message) => self.handle_message(from, message, now, io),

--- a/src/gossipswarm/hyparview.rs
+++ b/src/gossipswarm/hyparview.rs
@@ -17,7 +17,7 @@ use super::{util::IndexSet, PeerAddress, IO};
 
 #[derive(Debug)]
 pub enum InEvent<PA> {
-    Message(PA, Message<PA>),
+    RecvMessage(PA, Message<PA>),
     TimerExpired(Timer),
     PeerDisconnected(PA),
     RequestJoin(PA),
@@ -176,7 +176,7 @@ where
 {
     pub fn handle(&mut self, event: InEvent<PA>, io: &mut impl IO<PA>) {
         match event {
-            InEvent::Message(from, message) => self.handle_message(from, message, io),
+            InEvent::RecvMessage(from, message) => self.handle_message(from, message, io),
             InEvent::TimerExpired(timer) => match timer {
                 Timer::DoShuffle => self.do_shuffle(io),
             },
@@ -266,7 +266,7 @@ where
             ));
             self.shuffle_scheduled = true;
         }
-        if details.high_priority || !self.passive_is_full() {
+        if details.high_priority || !self.active_is_full() {
             self.add_active(from, details.high_priority, io)
         }
     }

--- a/src/gossipswarm/hyparview.rs
+++ b/src/gossipswarm/hyparview.rs
@@ -1,0 +1,431 @@
+//! Implementation of the HyParView membership protocol
+//!
+//! The implementation is based on [this paper][paper] by Joao Leitao, Jose Pereira, Luıs Rodrigues
+//! and the [example implementation][impl] by Bartosz Sypytkowski
+//!
+//! [paper]: https://asc.di.fct.unl.pt/~jleitao/pdf/dsn07-leitao.pdf
+//! [impl]: https://gist.github.com/Horusiath/84fac596101b197da0546d1697580d99
+
+use std::{collections::HashSet, hash::Hash, time::Duration};
+
+use derive_more::{From, Sub};
+use rand::rngs::ThreadRng;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+use super::{util::IndexSet, PeerAddress, IO};
+
+#[derive(Debug)]
+pub enum InEvent<PA> {
+    Message(PA, Message<PA>),
+    TimerExpired(Timer),
+    PeerDisconnected(PA),
+    RequestJoin(PA),
+}
+
+pub enum OutEvent<PA> {
+    SendMessage(PA, Message<PA>),
+    ScheduleTimer(Duration, Timer),
+    DisconnectPeer(PA),
+    EmitEvent(Event<PA>),
+}
+
+#[derive(Clone, Debug)]
+pub enum Event<PA> {
+    NeighborUp(PA),
+    NeighborDown(PA),
+}
+
+#[derive(Debug)]
+pub enum Timer {
+    DoShuffle,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum Message<PA> {
+    /// Sent to a peer if you want to join the swarm
+    Join,
+    /// When receiving Join, ForwardJoin is forwarded to the peer's ActiveView to introduce the
+    /// new member.
+    ForwardJoin(ForwardJoin<PA>),
+    /// A shuffle request is sent occasionally to re-shuffle the PassiveView with contacts from
+    /// other peers.
+    Shuffle(Shuffle<PA>),
+    /// Peers reply to Shuffle requests with a random subset of their PassiveView.
+    ShuffleReply(ShuffleReply<PA>),
+    /// Request to add sender to an active view of recipient. If `highPriority` is set, it cannot
+    /// be denied.
+    Neighbor(Neighbor),
+    /// Disconnect request. If `alive` is set, sender can safely be added to passive set for future
+    /// reconnections.
+    /// If `response` is set, recipient should answer with its own `Disconnect` (with
+    /// respond=false) as well.
+    Disconnect(Disconnect),
+}
+
+#[derive(From, Sub, Eq, PartialEq, Clone, Debug, Copy, Serialize, Deserialize)]
+pub struct Ttl(pub u16);
+impl Ttl {
+    pub fn expired(&self) -> bool {
+        *self == Ttl(0)
+    }
+    pub fn next(&self) -> Ttl {
+        *self - Ttl(1)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ForwardJoin<PA> {
+    peer: PA,
+    ttl: Ttl,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Shuffle<PA> {
+    origin: PA,
+    nodes: Vec<PA>,
+    ttl: Ttl,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ShuffleReply<PA> {
+    nodes: Vec<PA>,
+}
+
+impl<PA: Hash + Eq> ShuffleReply<PA> {
+    pub fn from_iter(nodes: impl IntoIterator<Item = PA>) -> Self {
+        Self {
+            nodes: HashSet::<PA>::from_iter(nodes.into_iter())
+                .into_iter()
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Neighbor {
+    high_priority: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Disconnect {
+    alive: Alive,
+    respond: Respond,
+}
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub active_view_capacity: usize,
+    pub passive_view_capacity: usize,
+    pub active_random_walk_length: Ttl,
+    pub passive_random_walk_length: Ttl,
+    pub shuffle_ttl: Ttl,
+    pub shuffle_active_view_count: usize,
+    pub shuffle_passive_view_count: usize,
+    pub shuffle_interval: Duration,
+}
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            active_view_capacity: 5,
+            passive_view_capacity: 24,
+            active_random_walk_length: Ttl(5),
+            passive_random_walk_length: Ttl(2),
+            shuffle_ttl: Ttl(2),
+            shuffle_active_view_count: 2,
+            shuffle_passive_view_count: 2,
+            shuffle_interval: Duration::from_secs(60),
+        }
+    }
+}
+
+pub type Respond = bool;
+pub type Alive = bool;
+
+#[derive(Debug)]
+pub struct State<PA, RG = ThreadRng> {
+    me: PA,
+    active_view: IndexSet<PA>,
+    passive_view: IndexSet<PA>,
+    config: Config,
+    shuffle_scheduled: bool,
+    rng: RG,
+}
+
+impl<PA> State<PA, rand::rngs::OsRng>
+where
+    PA: PeerAddress,
+{
+    pub fn new(me: PA, config: Config) -> Self {
+        Self {
+            me,
+            active_view: IndexSet::new(),
+            passive_view: IndexSet::new(),
+            config,
+            shuffle_scheduled: false,
+            rng: rand::rngs::OsRng,
+        }
+    }
+}
+
+impl<PA, RG> State<PA, RG>
+where
+    PA: PeerAddress,
+    RG: Rng,
+{
+    pub fn handle(&mut self, event: InEvent<PA>, io: &mut impl IO<PA>) {
+        match event {
+            InEvent::Message(from, message) => self.handle_message(from, message, io),
+            InEvent::TimerExpired(timer) => match timer {
+                Timer::DoShuffle => self.do_shuffle(io),
+            },
+            InEvent::PeerDisconnected(peer) => self.handle_disconnect(peer, io),
+            InEvent::RequestJoin(peer) => self.handle_join(peer, io),
+        }
+    }
+
+    fn handle_message(&mut self, from: PA, message: Message<PA>, io: &mut impl IO<PA>) {
+        let is_disconnect = matches!(message, Message::Disconnect(Disconnect { .. }));
+        match message {
+            Message::Join => self.on_join(from, io),
+            Message::ForwardJoin(details) => self.on_forward_join(from, details, io),
+            Message::Shuffle(details) => self.on_shuffle(from, details, io),
+            Message::ShuffleReply(details) => self.on_shuffle_reply(details),
+            Message::Neighbor(details) => self.on_neighbor(from, details, io),
+            Message::Disconnect(details) => self.on_disconnect(from, details, io),
+        }
+
+        // Disconnect from passive nodes right after receiving a message.
+        if !is_disconnect && !self.active_view.contains(&from) {
+            let message = Message::Disconnect(Disconnect {
+                alive: true,
+                respond: false,
+            });
+            io.push(OutEvent::SendMessage(from, message));
+            io.push(OutEvent::DisconnectPeer(from));
+        }
+    }
+
+    fn handle_join(&mut self, peer: PA, io: &mut impl IO<PA>) {
+        io.push(OutEvent::SendMessage(peer, Message::Join));
+    }
+
+    fn handle_disconnect(&mut self, peer: PA, io: &mut impl IO<PA>) {
+        self.on_disconnect(
+            peer,
+            // TODO: Is true, true correct? Recheck with paper.
+            Disconnect {
+                alive: true,
+                respond: true,
+            },
+            io,
+        );
+    }
+
+    fn on_join(&mut self, peer: PA, io: &mut impl IO<PA>) {
+        self.add_active(peer.clone(), true, io);
+        let ttl = self.config.active_random_walk_length;
+        for node in self.active_view.iter_without(&peer) {
+            let message = Message::ForwardJoin(ForwardJoin {
+                peer: peer.clone(),
+                ttl,
+            });
+            io.push(OutEvent::SendMessage(node.clone(), message));
+        }
+    }
+
+    fn on_forward_join(&mut self, sender: PA, message: ForwardJoin<PA>, io: &mut impl IO<PA>) {
+        if message.ttl.expired() || self.active_view.is_empty() {
+            self.add_active(message.peer, true, io);
+        } else {
+            if message.ttl == self.config.passive_random_walk_length {
+                self.add_passive(message.peer);
+            }
+            match self
+                .active_view
+                .pick_random_without(&[&sender], &mut self.rng)
+            {
+                None => self.add_active(message.peer, true, io),
+                Some(next) => {
+                    let message = Message::ForwardJoin(ForwardJoin {
+                        peer: message.peer,
+                        ttl: message.ttl.next(),
+                    });
+                    io.push(OutEvent::SendMessage(*next, message));
+                }
+            }
+        }
+    }
+
+    fn on_neighbor(&mut self, from: PA, details: Neighbor, io: &mut impl IO<PA>) {
+        if !self.shuffle_scheduled {
+            io.push(OutEvent::ScheduleTimer(
+                self.config.shuffle_interval,
+                Timer::DoShuffle,
+            ));
+            self.shuffle_scheduled = true;
+        }
+        if details.high_priority || !self.passive_is_full() {
+            self.add_active(from, details.high_priority, io)
+        }
+    }
+
+    fn on_shuffle(&mut self, from: PA, shuffle: Shuffle<PA>, io: &mut impl IO<PA>) {
+        if shuffle.ttl.expired() {
+            let len = shuffle.nodes.len();
+            for node in shuffle.nodes {
+                self.add_passive(node);
+            }
+            let nodes = self.passive_view.shuffled_max(len, &mut self.rng);
+            let message = Message::ShuffleReply(ShuffleReply::from_iter(nodes));
+            io.push(OutEvent::SendMessage(shuffle.origin, message));
+        } else {
+            if let Some(node) = self
+                .active_view
+                .pick_random_without(&[&shuffle.origin, &from], &mut self.rng)
+            {
+                let message = Message::Shuffle(Shuffle {
+                    origin: shuffle.origin,
+                    nodes: shuffle.nodes,
+                    ttl: shuffle.ttl.next(),
+                });
+                io.push(OutEvent::SendMessage(*node, message));
+            }
+        }
+    }
+
+    fn on_shuffle_reply(&mut self, message: ShuffleReply<PA>) {
+        for node in message.nodes {
+            self.add_passive(node);
+        }
+    }
+
+    fn on_disconnect(&mut self, peer: PA, details: Disconnect, io: &mut impl IO<PA>) {
+        if let Some(_) = self.remove_active(&peer, details.respond, io) {
+            if !self.active_is_full() {
+                if let Some(node) = self
+                    .passive_view
+                    .pick_random_without(&[&peer], &mut self.rng)
+                {
+                    let high_priority = self.active_view.is_empty();
+                    let message = Message::Neighbor(Neighbor { high_priority });
+                    io.push(OutEvent::SendMessage(*node, message));
+                }
+            }
+            if details.alive {
+                self.add_passive(peer.clone());
+            }
+        }
+    }
+
+    fn do_shuffle(&mut self, io: &mut impl IO<PA>) {
+        if let Some(node) = self.active_view.pick_random(&mut self.rng) {
+            let active = self.active_view.shuffled_without_max(
+                &[&node],
+                self.config.shuffle_active_view_count,
+                &mut self.rng,
+            );
+            let passive = self.passive_view.shuffled_without_max(
+                &[&node],
+                self.config.shuffle_passive_view_count,
+                &mut self.rng,
+            );
+            let mut nodes = HashSet::new();
+            nodes.extend(active);
+            nodes.extend(passive);
+            let message = Shuffle {
+                origin: self.me.clone(),
+                nodes: HashSet::<PA>::from_iter(nodes.into_iter())
+                    .into_iter()
+                    .collect(),
+                ttl: self.config.shuffle_ttl,
+            };
+            io.push(OutEvent::SendMessage(*node, Message::Shuffle(message)));
+        }
+        io.push(OutEvent::ScheduleTimer(
+            self.config.shuffle_interval,
+            Timer::DoShuffle,
+        ));
+    }
+
+    fn passive_is_full(&self) -> bool {
+        self.passive_view.len() >= self.config.passive_view_capacity
+    }
+
+    fn active_is_full(&self) -> bool {
+        self.active_view.len() >= self.config.active_view_capacity
+    }
+
+    /// Add a peer to the passive view.
+    ///
+    /// If the passive view is full, it will first remove a random peer and then insert the new peer.
+    /// If a peer is currently in the active view it will not be added.
+    fn add_passive(&mut self, peer: PA) {
+        if self.active_view.contains(&peer) || self.passive_view.contains(&peer) || peer == self.me
+        {
+            return;
+        }
+        if self.passive_is_full() {
+            self.passive_view.remove_random(&mut self.rng);
+        }
+        self.passive_view.insert(peer);
+    }
+
+    /// Remove a peer from the active view.
+    ///
+    /// If respond is true, a Disconnect message will be sent to the peer.
+    fn remove_active(&mut self, peer: &PA, respond: Respond, io: &mut impl IO<PA>) -> Option<PA> {
+        self.active_view
+            .get_index_of(peer)
+            .and_then(|idx| self.remove_active_by_index(idx, respond, io))
+    }
+
+    fn remove_active_by_index(
+        &mut self,
+        peer_index: usize,
+        respond: Respond,
+        io: &mut impl IO<PA>,
+    ) -> Option<PA> {
+        if let Some(peer) = self.active_view.remove_index(peer_index) {
+            if respond {
+                let message = Message::Disconnect(Disconnect {
+                    alive: true,
+                    respond: false,
+                });
+                io.push(OutEvent::SendMessage(peer, message));
+            }
+            io.push(OutEvent::DisconnectPeer(peer));
+            io.push(OutEvent::EmitEvent(Event::NeighborDown(peer)));
+            self.add_passive(peer);
+            Some(peer)
+        } else {
+            None
+        }
+    }
+
+    /// Remove a random peer from the active view.
+    fn remove_active_random(&mut self, io: &mut impl IO<PA>) {
+        if let Some(index) = self.active_view.pick_random_index(&mut self.rng) {
+            self.remove_active_by_index(index, true, io);
+        }
+    }
+
+    /// Add a peer to the active view.
+    ///
+    /// If the active view is currently full, a random peer will be removed first.
+    /// Sends a Neighbor message to the peer. If high_priority is true, the peer
+    /// may not deny the Neighbor request.
+    fn add_active(&mut self, peer: PA, high_priority: bool, io: &mut impl IO<PA>) {
+        if self.active_view.contains(&peer) || peer == self.me {
+            return;
+        }
+        if self.active_is_full() {
+            self.remove_active_random(io);
+        }
+        self.passive_view.remove(&peer);
+        self.active_view.insert(peer.clone());
+        let message = Message::Neighbor(Neighbor { high_priority });
+        io.push(OutEvent::SendMessage(peer, message));
+        io.push(OutEvent::EmitEvent(Event::NeighborUp(peer)));
+    }
+}

--- a/src/gossipswarm/hyparview.rs
+++ b/src/gossipswarm/hyparview.rs
@@ -6,26 +6,31 @@
 //! [paper]: https://asc.di.fct.unl.pt/~jleitao/pdf/dsn07-leitao.pdf
 //! [impl]: https://gist.github.com/Horusiath/84fac596101b197da0546d1697580d99
 
-use std::{collections::HashSet, hash::Hash, time::Duration};
+use std::{
+    collections::HashSet,
+    hash::Hash,
+    time::{Duration, Instant},
+};
 
 use derive_more::{From, Sub};
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 use super::{util::IndexSet, PeerAddress, IO};
 
 #[derive(Debug)]
 pub enum InEvent<PA> {
     RecvMessage(PA, Message<PA>),
-    TimerExpired(Timer),
+    TimerExpired(Timer<PA>),
     PeerDisconnected(PA),
     RequestJoin(PA),
 }
 
 pub enum OutEvent<PA> {
     SendMessage(PA, Message<PA>),
-    ScheduleTimer(Duration, Timer),
+    ScheduleTimer(Duration, Timer<PA>),
     DisconnectPeer(PA),
     EmitEvent(Event<PA>),
 }
@@ -37,8 +42,9 @@ pub enum Event<PA> {
 }
 
 #[derive(Debug)]
-pub enum Timer {
+pub enum Timer<PA> {
     DoShuffle,
+    PendingNeighborRequest(PA),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -71,7 +77,7 @@ impl Ttl {
         *self == Ttl(0)
     }
     pub fn next(&self) -> Ttl {
-        *self - Ttl(1)
+        Ttl(self.0.saturating_sub(1))
     }
 }
 
@@ -93,6 +99,12 @@ pub struct ShuffleReply<PA> {
     nodes: Vec<PA>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub enum Priority {
+    High,
+    Low,
+}
+
 impl<PA: Hash + Eq> ShuffleReply<PA> {
     pub fn from_iter(nodes: impl IntoIterator<Item = PA>) -> Self {
         Self {
@@ -105,7 +117,7 @@ impl<PA: Hash + Eq> ShuffleReply<PA> {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Neighbor {
-    high_priority: bool,
+    priority: Priority,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -124,6 +136,9 @@ pub struct Config {
     pub shuffle_active_view_count: usize,
     pub shuffle_passive_view_count: usize,
     pub shuffle_interval: Duration,
+
+    /// Timeout after which a Neighbor request is considered failed
+    pub neighbor_request_timeout: Duration,
 }
 impl Default for Config {
     fn default() -> Self {
@@ -136,6 +151,7 @@ impl Default for Config {
             shuffle_active_view_count: 3,
             shuffle_passive_view_count: 4,
             shuffle_interval: Duration::from_secs(60),
+            neighbor_request_timeout: Duration::from_millis(500),
         }
     }
 }
@@ -143,14 +159,21 @@ impl Default for Config {
 pub type Respond = bool;
 pub type Alive = bool;
 
+#[derive(Default, Debug, Clone)]
+pub struct Stats {
+    total_connections: usize,
+}
+
 #[derive(Debug)]
 pub struct State<PA, RG = ThreadRng> {
     me: PA,
-    active_view: IndexSet<PA>,
-    passive_view: IndexSet<PA>,
+    pub(crate) active_view: IndexSet<PA>,
+    pub(crate) passive_view: IndexSet<PA>,
     config: Config,
     shuffle_scheduled: bool,
     rng: RG,
+    stats: Stats,
+    pending_neighbor_requests: HashSet<PA>,
 }
 
 impl<PA> State<PA, rand::rngs::OsRng>
@@ -165,6 +188,8 @@ where
             config,
             shuffle_scheduled: false,
             rng: rand::rngs::OsRng,
+            stats: Stats::default(),
+            pending_neighbor_requests: Default::default(),
         }
     }
 }
@@ -174,22 +199,24 @@ where
     PA: PeerAddress,
     RG: Rng,
 {
-    pub fn handle(&mut self, event: InEvent<PA>, io: &mut impl IO<PA>) {
-        // this will only happen on the first call. maybe put into an Message::Init step instead
+    pub fn handle(&mut self, event: InEvent<PA>, now: Instant, io: &mut impl IO<PA>) {
+        match event {
+            InEvent::RecvMessage(from, message) => self.handle_message(from, message, now, io),
+            InEvent::TimerExpired(timer) => match timer {
+                Timer::DoShuffle => self.handle_shuffle_timer(io),
+                Timer::PendingNeighborRequest(peer) => self.handle_pending_neighbor_timer(peer, io),
+            },
+            InEvent::PeerDisconnected(peer) => self.handle_disconnect(peer, io),
+            InEvent::RequestJoin(peer) => self.handle_join(peer, io),
+        }
+
+        // this will only happen on the first call
         if !self.shuffle_scheduled {
             io.push(OutEvent::ScheduleTimer(
                 self.config.shuffle_interval,
                 Timer::DoShuffle,
             ));
             self.shuffle_scheduled = true;
-        }
-        match event {
-            InEvent::RecvMessage(from, message) => self.handle_message(from, message, io),
-            InEvent::TimerExpired(timer) => match timer {
-                Timer::DoShuffle => self.do_shuffle(io),
-            },
-            InEvent::PeerDisconnected(peer) => self.handle_disconnect(peer, io),
-            InEvent::RequestJoin(peer) => self.handle_join(peer, io),
         }
     }
 
@@ -201,24 +228,28 @@ where
         self.passive_view.iter()
     }
 
-    fn handle_message(&mut self, from: PA, message: Message<PA>, io: &mut impl IO<PA>) {
+    fn handle_message(
+        &mut self,
+        from: PA,
+        message: Message<PA>,
+        now: Instant,
+        io: &mut impl IO<PA>,
+    ) {
         let is_disconnect = matches!(message, Message::Disconnect(Disconnect { .. }));
+        if !is_disconnect && !self.active_view.contains(&from) {
+            self.stats.total_connections += 1;
+        }
         match message {
-            Message::Join => self.on_join(from, io),
-            Message::ForwardJoin(details) => self.on_forward_join(from, details, io),
+            Message::Join => self.on_join(from, now, io),
+            Message::ForwardJoin(details) => self.on_forward_join(from, details, now, io),
             Message::Shuffle(details) => self.on_shuffle(from, details, io),
             Message::ShuffleReply(details) => self.on_shuffle_reply(details),
-            Message::Neighbor(details) => self.on_neighbor(from, details, io),
+            Message::Neighbor(details) => self.on_neighbor(from, details, now, io),
             Message::Disconnect(details) => self.on_disconnect(from, details, io),
         }
 
         // Disconnect from passive nodes right after receiving a message.
         if !is_disconnect && !self.active_view.contains(&from) {
-            let message = Message::Disconnect(Disconnect {
-                alive: true,
-                respond: false,
-            });
-            io.push(OutEvent::SendMessage(from, message));
             io.push(OutEvent::DisconnectPeer(from));
         }
     }
@@ -230,19 +261,18 @@ where
     fn handle_disconnect(&mut self, peer: PA, io: &mut impl IO<PA>) {
         self.on_disconnect(
             peer,
-            // TODO: Is true, true correct? Recheck with paper.
             Disconnect {
                 alive: true,
-                respond: true,
+                respond: false,
             },
             io,
         );
     }
 
-    fn on_join(&mut self, peer: PA, io: &mut impl IO<PA>) {
+    fn on_join(&mut self, peer: PA, now: Instant, io: &mut impl IO<PA>) {
         // "A node that receives a join request will start by adding the new
         // node to its active view, even if it has to drop a random node from it. (6)"
-        self.add_active(peer.clone(), true, io);
+        self.add_active(peer, Priority::High, now, io);
         // "The contact node c will then send to all other nodes in its active view a ForwardJoin
         // request containing the new node identifier. Associated to the join procedure,
         // there are two configuration parameters, named Active Random Walk Length (ARWL),
@@ -252,38 +282,45 @@ where
         // a “time to live” field that is initially set to ARWL and decreased at every hop. (7)"
         let ttl = self.config.active_random_walk_length;
         for node in self.active_view.iter_without(&peer) {
-            let message = Message::ForwardJoin(ForwardJoin {
-                peer: peer.clone(),
-                ttl,
-            });
-            io.push(OutEvent::SendMessage(node.clone(), message));
+            let message = Message::ForwardJoin(ForwardJoin { peer, ttl });
+            io.push(OutEvent::SendMessage(*node, message));
         }
     }
 
-    fn on_forward_join(&mut self, sender: PA, message: ForwardJoin<PA>, io: &mut impl IO<PA>) {
+    fn on_forward_join(
+        &mut self,
+        sender: PA,
+        message: ForwardJoin<PA>,
+        now: Instant,
+        io: &mut impl IO<PA>,
+    ) {
         // "i) If the time to live is equal to zero or if the number of nodes in p’s active view is equal to one,
         // it will add the new node to its active view (7)"
         if message.ttl.expired() || self.active_view.len() <= 1 {
-            self.add_active(message.peer, true, io);
-        } else {
-            // "ii) If the time to live is equal to PRWL, p will insert the new node into its passive view"
-            if message.ttl == self.config.passive_random_walk_length {
-                self.add_passive(message.peer);
-            }
-            // "iii) The time to live field is decremented."
-            let ttl = message.ttl.next();
-            // "iv) If, at this point, n has not been inserted
-            // in p’s active view, p will forward the request to a random node in its active view
-            // (different from the one from which the request was received)."
+            self.add_active(message.peer, Priority::High, now, io);
+        }
+        // "ii) If the time to live is equal to PRWL, p will insert the new node into its passive view"
+        else if message.ttl == self.config.passive_random_walk_length {
+            self.add_passive(message.peer);
+        }
+        // "iii) The time to live field is decremented."
+        // "iv) If, at this point, n has not been inserted
+        // in p’s active view, p will forward the request to a random node in its active view
+        // (different from the one from which the request was received)."
+        if !self.active_view.contains(&message.peer) {
             match self
                 .active_view
                 .pick_random_without(&[&sender], &mut self.rng)
             {
-                None => self.add_active(message.peer, true, io),
+                None => {
+                    // TODO: I think this is unreachable!() but will have to check, maybe decrease
+                    // to warn
+                    unreachable!("no peers in active view but also did not add this node on forward join, this should not happen");
+                }
                 Some(next) => {
                     let message = Message::ForwardJoin(ForwardJoin {
                         peer: message.peer,
-                        ttl,
+                        ttl: message.ttl.next(),
                     });
                     io.push(OutEvent::SendMessage(*next, message));
                 }
@@ -291,13 +328,20 @@ where
         }
     }
 
-    fn on_neighbor(&mut self, from: PA, details: Neighbor, io: &mut impl IO<PA>) {
+    fn on_neighbor(&mut self, from: PA, details: Neighbor, now: Instant, io: &mut impl IO<PA>) {
+        self.pending_neighbor_requests.remove(&from);
         // "A node q that receives a high priority neighbor request will always accept the request, even
         // if it has to drop a random member from its active view (again, the member that is dropped will
         // receive a Disconnect notification). If a node q receives a low priority Neighbor request, it will
         // only accept the request if it has a free slot in its active view, otherwise it will refuse the request."
-        if details.high_priority || !self.active_is_full() {
-            self.add_active(from, details.high_priority, io)
+        match details.priority {
+            Priority::High => {
+                self.add_active(from, Priority::High, now, io);
+            }
+            Priority::Low if !self.active_is_full() => {
+                self.add_active(from, Priority::Low, now, io);
+            }
+            _ => {}
         }
     }
 
@@ -332,24 +376,16 @@ where
     }
 
     fn on_disconnect(&mut self, peer: PA, details: Disconnect, io: &mut impl IO<PA>) {
-        if let Some(_) = self.remove_active(&peer, details.respond, io) {
-            if !self.active_is_full() {
-                if let Some(node) = self
-                    .passive_view
-                    .pick_random_without(&[&peer], &mut self.rng)
-                {
-                    let high_priority = self.active_view.is_empty();
-                    let message = Message::Neighbor(Neighbor { high_priority });
-                    io.push(OutEvent::SendMessage(*node, message));
-                }
-            }
-            if details.alive {
-                self.add_passive(peer.clone());
-            }
+        self.pending_neighbor_requests.remove(&peer);
+        self.remove_active(&peer, details.respond, io);
+        if details.alive {
+            self.add_passive(peer);
+        } else {
+            self.passive_view.remove(&peer);
         }
     }
 
-    fn do_shuffle(&mut self, io: &mut impl IO<PA>) {
+    fn handle_shuffle_timer(&mut self, io: &mut impl IO<PA>) {
         if let Some(node) = self.active_view.pick_random(&mut self.rng) {
             let active = self.active_view.shuffled_without_max(
                 &[&node],
@@ -404,15 +440,64 @@ where
     ///
     /// If respond is true, a Disconnect message will be sent to the peer.
     fn remove_active(&mut self, peer: &PA, respond: Respond, io: &mut impl IO<PA>) -> Option<PA> {
-        self.active_view
-            .get_index_of(peer)
-            .and_then(|idx| self.remove_active_by_index(idx, respond, io))
+        self.active_view.get_index_of(peer).and_then(|idx| {
+            let removed_peer = self
+                .remove_active_by_index(idx, respond, RemovalReason::Disconnect, io)
+                .unwrap();
+
+            self.refill_active_from_passive(&[&removed_peer], io);
+
+            Some(removed_peer)
+        })
+    }
+
+    fn refill_active_from_passive(&mut self, skip_peers: &[&PA], io: &mut impl IO<PA>) {
+        if self.active_view.len() + self.pending_neighbor_requests.len()
+            >= self.config.active_view_capacity
+        {
+            return;
+        }
+        // "When a node p suspects that one of the nodes present in its active view has failed
+        // (by either disconnecting or blocking), it selects a random node q from its passive view and
+        // attempts to establish a TCP connection with q. If the connection fails to establish,
+        // node q is considered failed and removed from p’s passive view; another node q′ is selected
+        // at random and a new attempt is made. The procedure is repeated until a connection is established
+        // with success." (p7)
+        let mut skip_peers = skip_peers.to_vec();
+        skip_peers.extend(self.pending_neighbor_requests.iter());
+
+        if let Some(node) = self
+            .passive_view
+            .pick_random_without(&skip_peers, &mut self.rng)
+        {
+            let priority = match self.active_view.is_empty() {
+                true => Priority::High,
+                false => Priority::Low,
+            };
+            let message = Message::Neighbor(Neighbor { priority });
+            io.push(OutEvent::SendMessage(*node, message));
+            // schedule a timer that checks if the node replied with a neighbor message,
+            // otherwise try again with another passive node.
+            io.push(OutEvent::ScheduleTimer(
+                self.config.neighbor_request_timeout,
+                Timer::PendingNeighborRequest(*node),
+            ));
+            self.pending_neighbor_requests.insert(*node);
+        };
+    }
+
+    fn handle_pending_neighbor_timer(&mut self, peer: PA, io: &mut impl IO<PA>) {
+        if self.pending_neighbor_requests.remove(&peer) {
+            self.passive_view.remove(&peer);
+            self.refill_active_from_passive(&[], io);
+        }
     }
 
     fn remove_active_by_index(
         &mut self,
         peer_index: usize,
         respond: Respond,
+        reason: RemovalReason,
         io: &mut impl IO<PA>,
     ) -> Option<PA> {
         if let Some(peer) = self.active_view.remove_index(peer_index) {
@@ -426,6 +511,7 @@ where
             io.push(OutEvent::DisconnectPeer(peer));
             io.push(OutEvent::EmitEvent(Event::NeighborDown(peer)));
             self.add_passive(peer);
+            debug!(peer = ?self.me, other = ?peer, "removed from active view, reason: {reason:?}");
             Some(peer)
         } else {
             None
@@ -433,9 +519,9 @@ where
     }
 
     /// Remove a random peer from the active view.
-    fn remove_active_random(&mut self, io: &mut impl IO<PA>) {
+    fn free_random_slot_in_active_view(&mut self, io: &mut impl IO<PA>) {
         if let Some(index) = self.active_view.pick_random_index(&mut self.rng) {
-            self.remove_active_by_index(index, true, io);
+            self.remove_active_by_index(index, true, RemovalReason::Random, io);
         }
     }
 
@@ -444,17 +530,50 @@ where
     /// If the active view is currently full, a random peer will be removed first.
     /// Sends a Neighbor message to the peer. If high_priority is true, the peer
     /// may not deny the Neighbor request.
-    fn add_active(&mut self, peer: PA, high_priority: bool, io: &mut impl IO<PA>) {
+    fn add_active(
+        &mut self,
+        peer: PA,
+        priority: Priority,
+        _now: Instant,
+        io: &mut impl IO<PA>,
+    ) -> bool {
         if self.active_view.contains(&peer) || peer == self.me {
-            return;
+            return true;
         }
-        if self.active_is_full() {
-            self.remove_active_random(io);
+        match (priority, self.active_is_full()) {
+            (Priority::High, is_full) => {
+                if is_full {
+                    self.free_random_slot_in_active_view(io);
+                }
+                self.add_active_unchecked(peer, Priority::High, io);
+                true
+            }
+            (Priority::Low, false) => {
+                self.add_active_unchecked(peer, Priority::Low, io);
+                true
+            }
+            (Priority::Low, true) => false,
         }
+    }
+
+    fn add_active_unchecked(
+        &mut self,
+        peer: PA,
+        priority: Priority,
+        io: &mut impl IO<PA>,
+    ) {
         self.passive_view.remove(&peer);
-        self.active_view.insert(peer.clone());
-        let message = Message::Neighbor(Neighbor { high_priority });
+        self.active_view.insert(peer);
+        debug!(peer = ?self.me, other = ?peer, "add to active view");
+
+        let message = Message::Neighbor(Neighbor { priority });
         io.push(OutEvent::SendMessage(peer, message));
         io.push(OutEvent::EmitEvent(Event::NeighborUp(peer)));
     }
+}
+
+#[derive(Debug)]
+enum RemovalReason {
+    Disconnect,
+    Random,
 }

--- a/src/gossipswarm/hyparview.rs
+++ b/src/gossipswarm/hyparview.rs
@@ -41,7 +41,7 @@ pub enum Event<PA> {
     NeighborDown(PA),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Timer<PA> {
     DoShuffle,
     PendingNeighborRequest(PA),

--- a/src/gossipswarm/lib.rs
+++ b/src/gossipswarm/lib.rs
@@ -1,5 +1,0 @@
-pub mod gossipswarm;
-pub mod hyparview;
-// pub mod net;
-pub mod plumtree;
-mod util;

--- a/src/gossipswarm/lib.rs
+++ b/src/gossipswarm/lib.rs
@@ -1,0 +1,5 @@
+pub mod gossipswarm;
+pub mod hyparview;
+// pub mod net;
+pub mod plumtree;
+mod util;

--- a/src/gossipswarm/mod.rs
+++ b/src/gossipswarm/mod.rs
@@ -23,7 +23,7 @@ impl<T> PeerAddress for T where T: Hash + Eq + Copy + fmt::Debug + Ord + Seriali
 {}
 
 /// Input event to the state handler.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum InEvent<PA> {
     /// Message received from the network.
     RecvMessage(PA, Message<PA>),
@@ -106,13 +106,13 @@ impl<PA> From<plumtree::Event> for Event<PA> {
     }
 }
 
-#[derive(From, Debug)]
+#[derive(Clone, From, Debug)]
 pub enum Timer<PA> {
     Swarm(hyparview::Timer<PA>),
     Gossip(plumtree::Timer),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Command<PA> {
     Join(PA),
     Broadcast(Bytes),
@@ -385,8 +385,8 @@ mod test {
         let mut gossipswarm_config = Config::default();
         gossipswarm_config.broadcast.optimization_threshold = (read_var("OPTIM", 7) as u16).into();
         let mut config = SimulatorConfig::default();
-        config.peers_count = read_var("PEERS", 1000);
-        let rounds = read_var("ROUNDS", 50);
+        config.peers_count = read_var("PEERS", 100);
+        let rounds = read_var("ROUNDS", 10);
         let mut simulator = Simulator::new(config, gossipswarm_config);
         simulator.init();
         simulator.bootstrap();
@@ -404,8 +404,8 @@ mod test {
         let mut gossipswarm_config = Config::default();
         gossipswarm_config.broadcast.optimization_threshold = (read_var("OPTIM", 7) as u16).into();
         let mut config = SimulatorConfig::default();
-        config.peers_count = read_var("PEERS", 1000);
-        let rounds = read_var("ROUNDS", 50);
+        config.peers_count = read_var("PEERS", 100);
+        let rounds = read_var("ROUNDS", 10);
         let mut simulator = Simulator::new(config, gossipswarm_config);
         simulator.init();
         simulator.bootstrap();
@@ -799,7 +799,6 @@ mod test {
             sum
         }
     }
-
 
     /// A BtreeMap with Instant as key. Allows to process expired items.
     pub struct TimerMap<T>(BTreeMap<Instant, Vec<T>>);

--- a/src/gossipswarm/mod.rs
+++ b/src/gossipswarm/mod.rs
@@ -418,8 +418,13 @@ mod test {
             max_ticks: usize,
         ) {
             eprintln!("round {:?}", message[0]);
-            let mut expected: HashSet<usize> =
-                HashSet::from_iter(network.peers.iter().map(|p| *p.endpoint()));
+            let mut expected: HashSet<usize> = HashSet::from_iter(
+                network
+                    .peers
+                    .iter()
+                    .map(|p| *p.endpoint())
+                    .filter(|p| *p != from),
+            );
             let message: Bytes = message.into();
             network.command(from, Command::Broadcast(message.clone()));
             for i in 0..max_ticks {

--- a/src/gossipswarm/mod.rs
+++ b/src/gossipswarm/mod.rs
@@ -1,0 +1,462 @@
+use std::{collections::VecDeque, fmt, hash::Hash, time::Duration};
+
+use bytes::Bytes;
+use derive_more::From;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+mod hyparview;
+mod plumtree;
+mod util;
+
+use hyparview::InEvent as SwarmIn;
+use plumtree::InEvent as GossipIn;
+
+pub trait PeerAddress: Hash + Eq + Copy + fmt::Debug + Serialize + DeserializeOwned {}
+impl<T> PeerAddress for T where T: Hash + Eq + Copy + fmt::Debug + Serialize + DeserializeOwned {}
+
+/// Input event to the state handler.
+#[derive(Debug)]
+pub enum InEvent<PA> {
+    /// Message received from the network.
+    Message(PA, Message<PA>),
+    /// Execute a command from the application.
+    Command(Command<PA>),
+    /// Trigger a previously scheduled timer.
+    TimerExpired(Timer),
+    /// Peer disconnected on the network level.
+    PeerDisconnected(PA),
+}
+
+/// An output event from the state handler.
+#[derive(Debug)]
+pub enum OutEvent<PA> {
+    /// Send a message on the network
+    SendMessage(PA, Message<PA>),
+    /// Emit an event to the application.
+    EmitEvent(Event<PA>),
+    /// Schedule a timer. The runtime is responsible for sending an [InEvent::TimerExpired]
+    /// after the duration.
+    ScheduleTimer(Duration, Timer),
+    /// Close the connection to a peer on the network level.
+    DisconnectPeer(PA),
+}
+
+impl<PA> From<hyparview::OutEvent<PA>> for OutEvent<PA> {
+    fn from(event: hyparview::OutEvent<PA>) -> Self {
+        use hyparview::OutEvent::*;
+        match event {
+            SendMessage(to, message) => Self::SendMessage(to, message.into()),
+            ScheduleTimer(delay, timer) => Self::ScheduleTimer(delay, timer.into()),
+            DisconnectPeer(peer) => Self::DisconnectPeer(peer),
+            EmitEvent(event) => Self::EmitEvent(event.into()),
+        }
+    }
+}
+
+impl<PA> From<plumtree::OutEvent<PA>> for OutEvent<PA> {
+    fn from(event: plumtree::OutEvent<PA>) -> Self {
+        use plumtree::OutEvent::*;
+        match event {
+            SendMessage(to, message) => Self::SendMessage(to, message.into()),
+            ScheduleTimer(delay, timer) => Self::ScheduleTimer(delay, timer.into()),
+            EmitEvent(event) => Self::EmitEvent(event.into()),
+        }
+    }
+}
+
+pub trait IO<PA: Clone> {
+    fn push(&mut self, event: impl Into<OutEvent<PA>>);
+}
+
+#[derive(From, Debug, Serialize, Deserialize, Clone)]
+pub enum Message<PA> {
+    Swarm(hyparview::Message<PA>),
+    Gossip(plumtree::Message),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Event<PA> {
+    NeighborUp(PA),
+    NeighborDown(PA),
+    Received(Bytes),
+}
+
+impl<PA> From<hyparview::Event<PA>> for Event<PA> {
+    fn from(value: hyparview::Event<PA>) -> Self {
+        match value {
+            hyparview::Event::NeighborUp(peer) => Self::NeighborUp(peer),
+            hyparview::Event::NeighborDown(peer) => Self::NeighborDown(peer),
+        }
+    }
+}
+
+impl<PA> From<plumtree::Event> for Event<PA> {
+    fn from(value: plumtree::Event) -> Self {
+        match value {
+            plumtree::Event::Received(peer) => Self::Received(peer),
+        }
+    }
+}
+
+#[derive(From, Debug)]
+pub enum Timer {
+    Swarm(hyparview::Timer),
+    Gossip(plumtree::Timer),
+}
+
+#[derive(Debug)]
+pub enum Command<PA> {
+    Join(PA),
+    Broadcast(Bytes),
+}
+
+impl<PA: Clone> IO<PA> for VecDeque<OutEvent<PA>> {
+    fn push(&mut self, event: impl Into<OutEvent<PA>>) {
+        self.push_back(event.into())
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct Config {
+    pub membership: hyparview::Config,
+    pub broadcast: plumtree::Config,
+}
+
+/// The Gossipswarm maintains the state of peer network and sends and receives gossip messages over
+/// the swarm.
+#[derive(Debug)]
+pub struct State<PA> {
+    me: PA,
+    swarm: hyparview::State<PA, rand::rngs::OsRng>,
+    gossip: plumtree::State<PA>,
+    outbox: VecDeque<OutEvent<PA>>,
+}
+
+impl<PA: PeerAddress> State<PA> {
+    /// Initialize the local state.
+    pub fn new(me: PA, config: Config) -> Self {
+        Self {
+            swarm: hyparview::State::new(me.clone(), config.membership),
+            gossip: plumtree::State::new(me.clone(), config.broadcast),
+            me,
+            outbox: VecDeque::new(),
+        }
+    }
+
+    /// The address of your local endpoint.
+    pub fn endpoint(&self) -> &PA {
+        &self.me
+    }
+
+    /// Handle an incoming event.
+    ///
+    /// Returns an iterator of outgoing events that must be processed by the application.
+    #[must_use]
+    pub fn handle<'a>(&'a mut self, event: InEvent<PA>) -> impl Iterator<Item = OutEvent<PA>> + 'a {
+        let io = &mut self.outbox;
+        // Process the event, store out events in outbox.
+        match event {
+            InEvent::Command(command) => match command {
+                Command::Join(peer) => self.swarm.handle(SwarmIn::RequestJoin(peer), io),
+                Command::Broadcast(data) => self.gossip.handle(GossipIn::Broadcast(data), io),
+            },
+            InEvent::Message(from, message) => match message {
+                Message::Swarm(message) => self.swarm.handle(SwarmIn::Message(from, message), io),
+                Message::Gossip(message) => {
+                    self.gossip.handle(GossipIn::Message(from, message), io)
+                }
+            },
+            InEvent::TimerExpired(timer) => match timer {
+                Timer::Swarm(timer) => self.swarm.handle(SwarmIn::TimerExpired(timer), io),
+                Timer::Gossip(timer) => self.gossip.handle(GossipIn::TimerExpired(timer), io),
+            },
+            InEvent::PeerDisconnected(peer) => {
+                self.swarm.handle(SwarmIn::PeerDisconnected(peer), io)
+            }
+        }
+
+        // Forward NeigborUp and NeighborDown events from hyparview to plumtree
+        for event in self.outbox.iter() {
+            let mut io = VecDeque::new();
+            match event {
+                OutEvent::EmitEvent(Event::NeighborUp(peer)) => self
+                    .gossip
+                    .handle(GossipIn::NeighborUp(peer.clone()), &mut io),
+                OutEvent::EmitEvent(Event::NeighborDown(peer)) => self
+                    .gossip
+                    .handle(GossipIn::NeighborDown(peer.clone()), &mut io),
+                _ => {}
+            }
+        }
+        self.outbox.drain(..)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        collections::{BTreeMap, HashMap, HashSet, VecDeque},
+        time::{Duration, Instant},
+    };
+
+    use super::{Command, Config, Event, InEvent, Message, OutEvent, PeerAddress, State, Timer};
+
+    #[test]
+    fn hyparview_smoke() {
+        // Create a network with 4 nodes and active_view_capacity 2
+        let mut config = Config::default();
+        config.membership.active_view_capacity = 2;
+        let mut network = Network::new(Instant::now());
+        for i in 0..4 {
+            network.push(State::new(i, config.clone()));
+        }
+
+        // Do some joins between nodes 0,1,2 and wait 3 ticks
+        network.command(0, Command::Join(1));
+        network.command(0, Command::Join(2));
+        network.command(1, Command::Join(2));
+        network.ticks(2);
+
+        // Confirm emitted events
+        let actual = network.events_sorted();
+        let expected = sort(vec![
+            (0, Event::NeighborUp(1)),
+            (0, Event::NeighborUp(2)),
+            (1, Event::NeighborUp(2)),
+            (1, Event::NeighborUp(0)),
+            (2, Event::NeighborUp(0)),
+            (2, Event::NeighborUp(1)),
+        ]);
+        assert_eq!(actual, expected);
+
+        // Confirm active connections
+        assert_eq!(network.conns(), vec![(0, 1), (0, 2), (1, 2)]);
+
+        // Now let node 3 join node 0.
+        // Node 0 is full, so it will disconnect from either node 1 or node 2.
+        network.command(3, Command::Join(0));
+        network.ticks(2);
+
+        // Confirm emitted events. There's two options because whether node 0 disconnects from
+        // node 1 or node 2 is random.
+        let actual = network.events_sorted();
+        let expected1 = sort(vec![
+            (3, Event::NeighborUp(0)),
+            (0, Event::NeighborUp(3)),
+            (0, Event::NeighborDown(1)),
+            (1, Event::NeighborDown(0)),
+        ]);
+        let expected2 = sort(vec![
+            (3, Event::NeighborUp(0)),
+            (0, Event::NeighborUp(3)),
+            (0, Event::NeighborDown(2)),
+            (2, Event::NeighborDown(0)),
+        ]);
+        assert!((actual == expected1) || (actual == expected2));
+
+        // Confirm active connections.
+        if actual == expected1 {
+            assert_eq!(network.conns(), vec![(0, 2), (0, 3), (1, 2)]);
+        } else {
+            assert_eq!(network.conns(), vec![(0, 1), (0, 3), (1, 2)]);
+        }
+    }
+
+    #[test]
+    fn plumtree_smoke() {
+        let config = Config::default();
+        let mut network = Network::new(Instant::now());
+        // build a network with 6 nodes
+        for i in 0..6 {
+            network.push(State::new(i, config.clone()));
+        }
+
+        // connect nodes 1 and 2 to node 0
+        (1..3).for_each(|i| network.command(i, Command::Join(0)));
+        // connect nodes 4 and 5 to node 3
+        (4..6).for_each(|i| network.command(i, Command::Join(3)));
+        // run 3 ticks and drain events
+        network.ticks(3);
+        let _ = network.events();
+
+        // now broadcast a first message
+        network.command(1, Command::Broadcast(b"hi1".to_vec().into()));
+        network.ticks(3);
+        let events = network.events();
+        let received: Vec<_> = events
+            .filter(|x| matches!(x, (_, Event::Received(_))))
+            .collect();
+        // message should be received by two other nodes
+        assert_eq!(received.len(), 2);
+
+        // now connect the two sections of the swarm
+        network.command(2, Command::Join(5));
+        network.ticks(4);
+        let _ = network.events();
+
+        // now broadcast again
+        network.command(1, Command::Broadcast(b"hi2".to_vec().into()));
+        network.ticks(8);
+        let events = network.events();
+        let received: Vec<_> = events
+            .filter(|x| matches!(x, (_, Event::Received(_))))
+            .collect();
+        // message should be received by all 5 other nodes
+        assert_eq!(received.len(), 5);
+    }
+
+    pub const TICK_DURATION: Duration = Duration::from_millis(50);
+
+    /// Test network implementation.
+    /// Stores events in VecDeques and processes on ticks.
+    /// Timers are checked after each tick. The local time is increased with TICK_DURATION before
+    /// each tick.
+    struct Network<PA> {
+        time: Instant,
+        tick_duration: Duration,
+        outqueue: Vec<(PA, OutEvent<PA>)>,
+        inqueues: HashMap<PA, VecDeque<(PA, Message<PA>)>>,
+        peers: HashMap<PA, State<PA>>,
+        conns: HashSet<ConnId<PA>>,
+        events: VecDeque<(PA, Event<PA>)>,
+        timers: TimerMap<(PA, Timer)>,
+    }
+    impl<PA> Network<PA> {
+        pub fn new(time: Instant) -> Self {
+            Self {
+                time,
+                tick_duration: TICK_DURATION,
+                outqueue: Default::default(),
+                inqueues: Default::default(),
+                peers: Default::default(),
+                conns: Default::default(),
+                events: Default::default(),
+                timers: TimerMap::new(),
+            }
+        }
+    }
+
+    impl<PA: PeerAddress + Ord> Network<PA> {
+        pub fn push(&mut self, peer: State<PA>) {
+            self.inqueues.insert(*peer.endpoint(), VecDeque::new());
+            self.peers.insert(*peer.endpoint(), peer);
+        }
+
+        pub fn events<'a>(&'a mut self) -> impl Iterator<Item = (PA, Event<PA>)> + 'a {
+            self.events.drain(..)
+        }
+
+        pub fn events_sorted(&mut self) -> Vec<(PA, Event<PA>)> {
+            sort(self.events().collect())
+        }
+
+        pub fn conns(&self) -> Vec<(PA, PA)> {
+            sort(self.conns.iter().cloned().map(Into::into).collect())
+        }
+
+        pub fn command(&mut self, peer: PA, command: Command<PA>) {
+            self.handle(peer, InEvent::Command(command));
+        }
+
+        pub fn ticks(&mut self, n: usize) {
+            (0..n).for_each(|_| self.tick())
+        }
+
+        pub fn tick(&mut self) {
+            // process outqueue (might have entries from commands)
+            self.process_outqueue();
+            // process timers
+            self.time += self.tick_duration;
+            for (_time, (peer, timer)) in self.timers.drain_until(&self.time) {
+                self.handle(peer, InEvent::TimerExpired(timer));
+            }
+            // process messages
+            for (peer, state) in self.peers.iter_mut() {
+                let queue = self.inqueues.get_mut(peer).unwrap();
+                while let Some((from, message)) = queue.pop_front() {
+                    // eprintln!("{from:?} -> {peer:?}: {message:?}");
+                    let out = state.handle(InEvent::Message(from, message));
+                    self.outqueue.extend(out.map(|ev| (*peer, ev)));
+                }
+            }
+            // process outqueue again
+            self.process_outqueue();
+        }
+
+        fn handle(&mut self, peer: PA, event: InEvent<PA>) {
+            let out = self.peers.get_mut(&peer).unwrap().handle(event);
+            self.outqueue.extend(out.map(|ev| (peer, ev)));
+        }
+
+        fn process_outqueue(&mut self) {
+            for (from, event) in self.outqueue.drain(..) {
+                match event {
+                    OutEvent::SendMessage(to, message) => {
+                        self.conns.insert((from, to).into());
+                        let queue = self.inqueues.get_mut(&to).unwrap();
+                        queue.push_back((from, message));
+                    }
+                    OutEvent::ScheduleTimer(delay, timer) => {
+                        let instant = self.time + delay;
+                        self.timers.insert(instant, (from, timer));
+                    }
+                    OutEvent::DisconnectPeer(to) => {
+                        self.conns.remove(&(from, to).into());
+                    }
+                    OutEvent::EmitEvent(event) => {
+                        // eprintln!("EVENT {from:?} {event:?}");
+                        self.events.push_back((from, event));
+                    }
+                }
+            }
+        }
+    }
+
+    /// A BtreeMap with Instant as key. Allows to process expired items.
+    pub struct TimerMap<T>(BTreeMap<Instant, Vec<T>>);
+    impl<T> TimerMap<T> {
+        pub fn new() -> Self {
+            Self(Default::default())
+        }
+        pub fn insert(&mut self, instant: Instant, item: T) {
+            let entry = self.0.entry(instant).or_default();
+            entry.push(item);
+        }
+        pub fn drain_until(&mut self, from: &Instant) -> impl Iterator<Item = (Instant, T)> {
+            let split_point = from.clone() + Duration::from_nanos(1);
+            let later_half = self.0.split_off(&split_point);
+            let expired = std::mem::replace(&mut self.0, later_half);
+            expired
+                .into_iter()
+                .map(|(t, v)| v.into_iter().map(move |v| (t, v)))
+                .flatten()
+        }
+    }
+
+    /// Helper struct for active connections. A sorted tuple.
+    #[derive(Debug, Clone, PartialOrd, Ord, Eq, PartialEq, Hash)]
+    pub struct ConnId<PA>([PA; 2]);
+    impl<PA: Ord> ConnId<PA> {
+        pub fn new(a: PA, b: PA) -> Self {
+            let mut conn = [a, b];
+            conn.sort();
+            Self(conn)
+        }
+    }
+    impl<PA: Ord> From<(PA, PA)> for ConnId<PA> {
+        fn from((a, b): (PA, PA)) -> Self {
+            Self::new(a, b)
+        }
+    }
+    impl<PA: Copy> From<ConnId<PA>> for (PA, PA) {
+        fn from(conn: ConnId<PA>) -> (PA, PA) {
+            (conn.0[0], conn.0[1])
+        }
+    }
+
+    fn sort<T: Ord + Clone>(items: Vec<T>) -> Vec<T> {
+        let mut sorted = items.clone();
+        sorted.sort();
+        sorted
+    }
+}

--- a/src/gossipswarm/plumtree.rs
+++ b/src/gossipswarm/plumtree.rs
@@ -154,8 +154,8 @@ impl Default for Config {
 
 #[derive(Debug, Default, Clone)]
 pub struct Stats {
-    pub payload_messages_received: u16,
-    pub control_messages_received: u16,
+    pub payload_messages_received: u64,
+    pub control_messages_received: u64,
 }
 
 #[derive(Debug)]

--- a/src/gossipswarm/plumtree.rs
+++ b/src/gossipswarm/plumtree.rs
@@ -1,0 +1,368 @@
+//! Implementation of the Plumtree epidemic broadcast tree protocol
+//! 
+//! The implementation is based on [this paper][paper] by Joao Leitao, Jose Pereira, Luıs Rodrigues
+//! and the [example implementation][impl] by Bartosz Sypytkowski
+//!
+//! [paper]: https://asc.di.fct.unl.pt/~jleitao/pdf/srds07-leitao.pdf
+//! [impl]: https://gist.github.com/Horusiath/84fac596101b197da0546d1697580d99
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    fmt,
+    hash::Hash,
+    time::Duration,
+};
+
+use bytes::Bytes;
+use derive_more::From;
+use indexmap::IndexSet;
+use serde::{Deserialize, Serialize};
+
+use super::{PeerAddress, IO};
+
+pub enum InEvent<PA> {
+    Message(PA, Message),
+    Broadcast(Bytes),
+    TimerExpired(Timer),
+    NeighborUp(PA),
+    NeighborDown(PA),
+}
+
+pub enum OutEvent<PA> {
+    SendMessage(PA, Message),
+    ScheduleTimer(Duration, Timer),
+    EmitEvent(Event),
+}
+
+#[derive(Clone, Debug)]
+pub enum Timer {
+    SendGraft(MessageId),
+    DispatchLazyPush,
+}
+
+#[derive(Clone, Debug)]
+pub enum Event {
+    Received(Bytes),
+}
+
+/// A message identifier, which is the message content's blake3 hash
+#[derive(Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
+pub struct MessageId([u8; 32]);
+
+impl From<blake3::Hash> for MessageId {
+    fn from(hash: blake3::Hash) -> Self {
+        Self(hash.into())
+    }
+}
+
+impl std::hash::Hash for MessageId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.0);
+    }
+}
+
+impl fmt::Display for MessageId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut text = data_encoding::BASE32_NOPAD.encode(&self.0);
+        text.make_ascii_lowercase();
+        write!(f, "{}", text)
+    }
+}
+impl fmt::Debug for MessageId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Id({})", self)
+    }
+}
+
+#[derive(From, Serialize, Deserialize, Eq, PartialEq, Clone, Copy, Debug, Hash)]
+pub struct Round(u16);
+
+impl Round {
+    pub fn next(&self) -> Round {
+        Round(self.0 + 1)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum Message {
+    Gossip(Gossip),
+    Prune,
+    IHave(Vec<IHave>),
+    Graft(Graft),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Gossip {
+    id: MessageId,
+    round: Round,
+    content: Bytes,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IHave {
+    id: MessageId,
+    round: Round,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Graft {
+    id: MessageId,
+    round: Round,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct LazyPush<PA> {
+    id: MessageId,
+    round: Round,
+    peer: PA,
+}
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    graft_timeout: Duration,
+    ihave_timeout: Duration,
+    dispatch_timeout: Duration,
+    // optimization_threshold: Round,
+}
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            graft_timeout: Duration::from_secs(1),
+            ihave_timeout: Duration::from_millis(30),
+            dispatch_timeout: Duration::from_millis(30), // optimization_threshold: Round(5),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct State<PA> {
+    me: PA,
+    eager_push_peers: HashSet<PA>,
+    lazy_push_peers: HashSet<PA>,
+    lazy_queue: VecDeque<LazyPush<PA>>,
+    config: Config,
+    missing_messages: IndexSet<LazyPush<PA>>,
+    received_messages: IndexSet<MessageId>,
+    timers: HashSet<MessageId>,
+    cache: HashMap<MessageId, Gossip>,
+    dispatch_timer_scheduled: bool,
+}
+
+impl<PA: PeerAddress> State<PA> {
+    pub fn new(me: PA, config: Config) -> Self {
+        Self {
+            me,
+            eager_push_peers: Default::default(),
+            lazy_push_peers: Default::default(),
+            lazy_queue: Default::default(),
+            config,
+            missing_messages: Default::default(),
+            received_messages: Default::default(),
+            timers: Default::default(),
+            cache: Default::default(),
+            dispatch_timer_scheduled: false,
+        }
+    }
+
+    pub fn handle(&mut self, event: InEvent<PA>, io: &mut impl IO<PA>) {
+        match event {
+            InEvent::Message(from, message) => self.handle_message(from, message, io),
+            InEvent::Broadcast(data) => self.do_broadcast(data, io),
+            InEvent::NeighborUp(peer) => self.on_neighbor_up(peer),
+            InEvent::NeighborDown(peer) => self.on_neighbor_down(peer),
+            InEvent::TimerExpired(timer) => match timer {
+                Timer::DispatchLazyPush => self.on_dispatch_timer(io),
+                Timer::SendGraft(id) => {
+                    self.on_send_graft_timer(id.clone(), io);
+                }
+            },
+        }
+    }
+
+    fn handle_message(&mut self, sender: PA, message: Message, io: &mut impl IO<PA>) {
+        match message {
+            Message::Gossip(details) => self.on_gossip(sender, details, io),
+            Message::Prune => self.on_prune(sender),
+            Message::IHave(details) => self.on_ihave(sender, details, io),
+            Message::Graft(details) => self.on_graft(sender, details, io),
+        }
+    }
+
+    /// Dispatches messages from lazy queue over to lazy peers.
+    fn on_dispatch_timer(&mut self, io: &mut impl IO<PA>) {
+        let gossips = {
+            let mut map = HashMap::new();
+            for LazyPush { id, round, peer } in self.lazy_queue.drain(..) {
+                let message = IHave { id, round };
+                match map.get_mut(&peer) {
+                    None => {
+                        map.insert(peer, vec![message]);
+                    }
+                    Some(list) => list.push(message),
+                };
+            }
+            map
+        };
+
+        for (peer, list) in gossips {
+            io.push(OutEvent::SendMessage(peer, Message::IHave(list)));
+        }
+
+        self.dispatch_timer_scheduled = false;
+    }
+
+    /// Send a gossip message.
+    /// Will be pushed in full to eager peers.
+    /// Pushing the message ids to the lazy peers is delayed by a timer.
+    fn do_broadcast(&mut self, data: Bytes, io: &mut impl IO<PA>) {
+        let id = blake3::hash(&data).into();
+        let message = Gossip {
+            id,
+            round: Round(0),
+            content: data,
+        };
+        let me = self.me.clone();
+        self.eager_push(message.clone(), &me, io);
+        self.lazy_push(message.clone(), &me, io);
+        self.received_messages.insert(id);
+        self.cache.insert(id, message);
+    }
+
+    // TODO: do_optimize
+
+    fn on_gossip(&mut self, sender: PA, message: Gossip, io: &mut impl IO<PA>) {
+        if self.received_messages.contains(&message.id) {
+            self.add_lazy(sender.clone());
+            io.push(OutEvent::SendMessage(sender, Message::Prune));
+        } else {
+            self.received_messages.insert(message.id);
+            let forward = Gossip {
+                id: message.id,
+                content: message.content.clone(),
+                round: message.round.next(),
+            };
+            self.eager_push(forward.clone(), &sender, io);
+            self.lazy_push(forward, &sender, io);
+            io.push(OutEvent::EmitEvent(Event::Received(message.content)));
+        }
+    }
+
+    fn on_prune(&mut self, sender: PA) {
+        self.add_lazy(sender);
+    }
+
+    fn on_ihave(&mut self, sender: PA, ihaves: Vec<IHave>, io: &mut impl IO<PA>) {
+        for ihave in ihaves {
+            if self.received_messages.contains(&ihave.id) {
+                let record = LazyPush {
+                    id: ihave.id,
+                    round: ihave.round,
+                    peer: sender.clone(),
+                };
+                self.missing_messages.insert(record);
+                self.timers.insert(ihave.id);
+                io.push(OutEvent::ScheduleTimer(
+                    self.config.ihave_timeout,
+                    Timer::SendGraft(ihave.id),
+                ));
+            }
+        }
+    }
+
+    fn on_send_graft_timer(&mut self, id: MessageId, io: &mut impl IO<PA>) {
+        if !self.timers.contains(&id) {
+            self.timers.insert(id);
+            io.push(OutEvent::ScheduleTimer(
+                self.config.graft_timeout,
+                Timer::SendGraft(id),
+            ));
+        }
+        if let Some(entry) = remove_first_match(&mut self.missing_messages, |x| x.id == id) {
+            self.add_eager(entry.peer.clone());
+            let message = Message::Graft(Graft {
+                id,
+                round: entry.round,
+            });
+            io.push(OutEvent::SendMessage(entry.peer, message));
+        }
+    }
+
+    fn on_graft(&mut self, sender: PA, details: Graft, io: &mut impl IO<PA>) {
+        self.add_eager(sender.clone());
+        if self.received_messages.contains(&details.id) {
+            if let Some(message) = self.cache.get(&details.id) {
+                io.push(OutEvent::SendMessage(
+                    sender,
+                    Message::Gossip(message.clone()),
+                ));
+            }
+        }
+    }
+
+    fn on_neighbor_up(&mut self, peer: PA) {
+        self.eager_push_peers.insert(peer);
+    }
+
+    fn on_neighbor_down(&mut self, peer: PA) {
+        self.missing_messages.retain(|keep| keep.peer != peer);
+        self.eager_push_peers.remove(&peer);
+        self.lazy_push_peers.remove(&peer);
+    }
+
+    /// Moves peer into eager set.
+    fn add_eager(&mut self, peer: PA) {
+        self.lazy_push_peers.remove(&peer);
+        self.eager_push_peers.insert(peer);
+    }
+
+    /// Moves peer into lazy set.
+    fn add_lazy(&mut self, peer: PA) {
+        self.eager_push_peers.remove(&peer);
+        self.lazy_push_peers.insert(peer);
+    }
+
+    /// Immediatelly sends message to eager peers.
+    fn eager_push(&mut self, gossip: Gossip, sender: &PA, io: &mut impl IO<PA>) {
+        for peer in self
+            .eager_push_peers
+            .iter()
+            .filter(|peer| **peer != self.me && *peer != sender)
+        {
+            io.push(OutEvent::SendMessage(
+                *peer,
+                Message::Gossip(gossip.clone()),
+            ));
+        }
+    }
+
+    /// Puts lazy message announcements on top of the queue which will be consumed into batched
+    /// IHave message once dispatch trigger activates (it's cyclic operation).
+    fn lazy_push(&mut self, gossip: Gossip, sender: &PA, io: &mut impl IO<PA>) {
+        for peer in self.lazy_push_peers.iter().filter(|x| *x != sender) {
+            self.lazy_queue.push_back(LazyPush {
+                peer: peer.clone(),
+                round: gossip.round,
+                id: gossip.id,
+            })
+        }
+        if !self.dispatch_timer_scheduled {
+            io.push(OutEvent::ScheduleTimer(
+                self.config.dispatch_timeout,
+                Timer::DispatchLazyPush,
+            ));
+            self.dispatch_timer_scheduled = true;
+        }
+    }
+}
+
+fn remove_first_match<T: Eq + Hash + Clone>(
+    set: &mut IndexSet<T>,
+    find: impl Fn(&T) -> bool,
+) -> Option<T> {
+    let found = set.iter().enumerate().find(|(_idx, value)| find(value));
+    if let Some((index, _found)) = found {
+        set.shift_remove_index(index)
+    } else {
+        None
+    }
+}

--- a/src/gossipswarm/plumtree.rs
+++ b/src/gossipswarm/plumtree.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use super::{PeerAddress, IO};
 
 pub enum InEvent<PA> {
-    Message(PA, Message),
+    RecvMessage(PA, Message),
     Broadcast(Bytes),
     TimerExpired(Timer),
     NeighborUp(PA),
@@ -70,7 +70,9 @@ impl fmt::Display for MessageId {
 }
 impl fmt::Debug for MessageId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Id({})", self)
+        let mut text = data_encoding::BASE32_NOPAD.encode(&self.0);
+        text.make_ascii_lowercase();
+        write!(f, "{}…{}", &text[..5], &text[(text.len() - 2)..])
     }
 }
 
@@ -175,7 +177,7 @@ impl<PA: PeerAddress> State<PA> {
 
     pub fn handle(&mut self, event: InEvent<PA>, io: &mut impl IO<PA>) {
         match event {
-            InEvent::Message(from, message) => self.handle_message(from, message, io),
+            InEvent::RecvMessage(from, message) => self.handle_message(from, message, io),
             InEvent::Broadcast(data) => self.do_broadcast(data, io),
             InEvent::NeighborUp(peer) => self.on_neighbor_up(peer),
             InEvent::NeighborDown(peer) => self.on_neighbor_down(peer),

--- a/src/gossipswarm/util.rs
+++ b/src/gossipswarm/util.rs
@@ -36,7 +36,7 @@ where
         self.inner.insert(value)
     }
 
-    pub fn contains(&mut self, value: &T) -> bool {
+    pub fn contains(&self, value: &T) -> bool {
         self.inner.contains(value)
     }
 

--- a/src/gossipswarm/util.rs
+++ b/src/gossipswarm/util.rs
@@ -1,0 +1,139 @@
+use rand::{
+    seq::{IteratorRandom, SliceRandom},
+    Rng,
+};
+use std::hash::Hash;
+
+/// A hash set where the iteration order of the values is independent of their
+/// hash values.
+///
+/// This is wrapper around [indexmap::IndexSet] that limits the removal API to
+/// always do shift_remove (preserving the order of other elements) and adds a
+/// couple of utility methods to randomly select elements from the set.
+#[derive(Default, Debug, Clone)]
+pub struct IndexSet<T> {
+    inner: indexmap::IndexSet<T>,
+}
+
+impl<T> IndexSet<T>
+where
+    T: Hash + Eq + PartialEq,
+{
+    pub fn new() -> Self {
+        Self {
+            inner: indexmap::IndexSet::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+    pub fn insert(&mut self, value: T) -> bool {
+        self.inner.insert(value)
+    }
+
+    pub fn contains(&mut self, value: &T) -> bool {
+        self.inner.contains(value)
+    }
+
+    pub fn get_index_of(&self, value: &T) -> Option<usize> {
+        self.inner.get_index_of(value)
+    }
+
+    /// Remove a random element from the set.
+    pub fn remove_random<R: Rng + ?Sized>(&mut self, rng: &mut R) -> Option<T> {
+        self.pick_random_index(rng)
+            .and_then(|idx| self.inner.shift_remove_index(idx))
+    }
+
+    /// Pick a random element from the set.
+    pub fn pick_random<R: Rng + ?Sized>(&self, rng: &mut R) -> Option<&T> {
+        self.pick_random_index(rng)
+            .and_then(|idx| self.inner.get_index(idx))
+    }
+
+    /// Pick a random element from the set, but not any of the elements in `without`.
+    pub fn pick_random_without<R: Rng + ?Sized>(&self, without: &[&T], rng: &mut R) -> Option<&T> {
+        self.iter().filter(|x| !without.contains(x)).choose(rng)
+    }
+
+    /// Pick a random index for an element in the set.
+    pub fn pick_random_index<R: Rng + ?Sized>(&self, rng: &mut R) -> Option<usize> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(rng.gen_range(0..self.inner.len()))
+        }
+    }
+
+    /// Remove an element from the set, while keeping the order of the other elements.
+    pub fn remove(&mut self, value: &T) -> Option<T> {
+        self.inner.shift_remove_full(value).map(|(_i, v)| v)
+    }
+
+    /// Remove an element from the set by its index.
+    pub fn remove_index(&mut self, index: usize) -> Option<T> {
+        self.inner.shift_remove_index(index)
+    }
+
+    /// Create an iterator over the set in the order of insertion.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.inner.iter()
+    }
+
+    /// Create an iterator over the set in the order of insertion, while skipping the element in
+    /// `without`.
+    pub fn iter_without<'a>(&'a self, value: &'a T) -> impl Iterator<Item = &'a T> {
+        self.iter().filter(move |x| *x != value)
+    }
+}
+
+impl<T> IndexSet<T>
+where
+    T: Hash + Eq + Clone,
+{
+    /// Create a vector of all elements in the set in random order.
+    pub fn shuffled<R: Rng + ?Sized>(&self, rng: &mut R) -> Vec<T> {
+        let mut items: Vec<_> = self.inner.iter().cloned().collect();
+        items.shuffle(rng);
+        items
+    }
+
+    /// Create a vector of all elements in the set in random order, and shorten to
+    /// the first `len` elements after shuffling.
+    pub fn shuffled_max<R: Rng + ?Sized>(&self, len: usize, rng: &mut R) -> Vec<T> {
+        let mut items = self.shuffled(rng);
+        items.truncate(len);
+        items
+    }
+
+    /// Create a vector of the elements in the set in random order while omitting
+    /// the elements in `without`.
+    pub fn shuffled_without<R: Rng + ?Sized>(&self, without: &[&T], rng: &mut R) -> Vec<T> {
+        let mut items = self
+            .inner
+            .iter()
+            .filter(|x| !without.contains(x))
+            .cloned()
+            .collect::<Vec<_>>();
+        items.shuffle(rng);
+        items
+    }
+
+    /// Create a vector of the elements in the set in random order while omitting
+    /// the elements in `without`, and shorten to the first `len` elements.
+    pub fn shuffled_without_max<R: Rng + ?Sized>(
+        &self,
+        without: &[&T],
+        len: usize,
+        rng: &mut R,
+    ) -> Vec<T> {
+        let mut items = self.shuffled_without(without, rng);
+        items.truncate(len);
+        items
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod api;
 pub mod ranger;
 pub mod sync;
+pub mod gossipswarm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod api;
+pub mod gossipswarm;
 pub mod ranger;
 pub mod sync;
-pub mod gossipswarm;


### PR DESCRIPTION
This PR contains the initial implementation of a `gossipswarm` module. The module exposes a protocol that combines [HyParView](https://asc.di.fct.unl.pt/~jleitao/pdf/dsn07-leitao.pdf) and [Plumtree](https://asc.di.fct.unl.pt/~jleitao/pdf/srds07-leitao.pdf).

The implementation is IO-less. It exposes a single public method `handle` where events are passed in (received messages, expired timers, application commands) and an iterator of events to process is returned (messages to send, timers to be scheduled, application events).

The implementation also is generic over a `PeerAddress`, which is an identifier chosen for each peer by the upper protocol/networking level (not yet implemented).

An initial smoke test for both HyParView and Plumtree passes. More tests are needed of course. Notably, the passive view management, lazy pushes andgossiping over time (basically all timers) are not yet tested.